### PR TITLE
Refactor Planet fetch, clean up helpers, fix People data format.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ class App extends Component {
         this.setState({ currentData: data });
       });
     } else {
-      console.log(`found ${requestType} in local storage`);
       this.setState({ currentData: cachedData });
     }
   }

--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -3,7 +3,7 @@ import './DataView.css';
 import Card from '../Card/Card';
 
 const DataView = ({ currentData }) => {
-  console.log('currentData', currentData);
+  console.log('currentData in DataView', currentData);
   return (
     <div className='card-container'>
       <Card />


### PR DESCRIPTION
Refactor planets fetch calls into helper methods.
Cleaned up helper methods to be more concise.
Fixed data format for People fetch calls so that we are getting back the full object that includes next/previous for pagination.